### PR TITLE
fix: When the basename is present, the params cannot be properly pars…

### DIFF
--- a/packages/vite-plugin-fake-server/src/getResponse.mjs
+++ b/packages/vite-plugin-fake-server/src/getResponse.mjs
@@ -78,7 +78,13 @@ export async function getResponse({
 				await sleep(timeout);
 			}
 
-			const urlMatch = basename.length > 0 ? match(`/${basename}${url}`) : match(url, { encode: encodeURI });
+			const basePathname = new URL(basename, "http://localhost:5173/").pathname;
+			const userPathname = new URL(url, "http://localhost:5173/").pathname;
+			const concatenatedPathname = basePathname.endsWith("/")
+				? basePathname.slice(0, -1) + userPathname
+				: basePathname + userPathname;
+
+			const urlMatch = match(concatenatedPathname, { encode: encodeURI });
 
 			const searchParams = instanceURL.searchParams;
 			const query = {};

--- a/packages/vite-plugin-fake-server/src/getResponse.mjs
+++ b/packages/vite-plugin-fake-server/src/getResponse.mjs
@@ -78,7 +78,7 @@ export async function getResponse({
 				await sleep(timeout);
 			}
 
-			const urlMatch = match(url, { encode: encodeURI });
+			const urlMatch = basename.length > 0 ? match(`/${basename}${url}`) : match(url, { encode: encodeURI });
 
 			const searchParams = instanceURL.searchParams;
 			const query = {};


### PR DESCRIPTION
修复当插件配置中填写`basename`时，路径参数`params`无法被正确解析的bug

`vite.config.js`
```
import { defineConfig } from "vite";
import vue from "@vitejs/plugin-vue";
import { vitePluginFakeServer } from "vite-plugin-fake-server";

// https://vitejs.dev/config/
export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
  return {
    plugins: [
      vue(),
      vitePluginFakeServer({
        include: "mock",
        exclude: ["utils"],
        infixName: false,
        basename: "api",
      }),
    ],
  };
});
```

`mock/modules/test.js`
```
export default [
  {
    url: "/car/:id",
    response({ params }) {
      return { params };
    },
  },
];
```

访问`http://localhost:5173/api/car/1234`时，响应：
```
{
  "params": {}
}
```