### PR TITLE
fix(修复某些框架利用new XMLHttpRequest  responseType 检测是否支持xhr2):

### DIFF
--- a/packages/vite-plugin-fake-server/src/xhook/index.mjs
+++ b/packages/vite-plugin-fake-server/src/xhook/index.mjs
@@ -607,6 +607,7 @@ export function xhook() {
 		facade.responseXML = null;
 		facade.readyState = 0;
 		facade.statusText = "";
+		facade.responseType = "";
 
 		return facade;
 	};


### PR DESCRIPTION
在开源项目 vue socket io ：https://github.com/MetinSeylan/Vue-Socket.io
是通过new XMLHttpRequest  responseType 判断是否支持二进制，但是集成[vite-plugin-fake-server](https://github.com/condorheroblog/vite-plugin-fake-server)后responseType没有赋值，导致判断失败。当前已经人工本地添加后正常。
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/99152470-dc8c-4c7a-a408-aa47474f9afc">
